### PR TITLE
ビルのラベル名を設定

### DIFF
--- a/layers/poi-building-label.yml
+++ b/layers/poi-building-label.yml
@@ -1,0 +1,44 @@
+id: poi-building-label
+type: symbol
+source: geolonia
+source-layer: poi
+minzoom: 13
+filter:
+  - all
+  - - 'has'
+    - wikidata
+  - - '!has'
+    - class
+  - - '=='
+    - rank
+    - 25
+  - - '!='
+    - disputed
+    - japan_northern_territories
+layout:
+  text-padding:
+    - interpolate
+    - - linear
+    - - zoom
+    - 14
+    - 50
+    - 17
+    - 2
+  text-font:
+    - Noto Sans CJK JP Light
+  text-anchor: top
+  icon-anchor: bottom
+  icon-image: circle-stroked
+  icon-size: 0.5
+  text-field: '{name}'
+  text-offset:
+    - 0
+    - 0.3
+  text-size: 12
+  text-max-width: 7
+  visibility: visible
+paint:
+  text-halo-blur: 1
+  text-color: '#000000'
+  text-halo-width: 1.5
+  text-halo-color: '#ffffff'

--- a/style.yml
+++ b/style.yml
@@ -4,10 +4,10 @@ $name: Geolonia Basic
 
 version: 8
 name: $name
-zoom: 14
+zoom: 15.5
 center:
-  - 135.45381
-  - 34.68353
+  - 139.69567
+  - 35.69228
 sources:
   oceanus:
     type: vector

--- a/style.yml
+++ b/style.yml
@@ -133,10 +133,11 @@ layers:
   # - !!inc/file layers/road_oneway.yml
   # - !!inc/file layers/road_oneway_opposite.yml
   # - !!inc/file layers/poi-bus.yml
-  - !!inc/file layers/poi-r25.yml
-  - !!inc/file layers/poi-r10-r24.yml
+  # - !!inc/file layers/poi-r25.yml
+  # - !!inc/file layers/poi-r10-r24.yml
   # - !!inc/file layers/poi-r0-r9.yml
   # - !!inc/file layers/poi-entrance.yml
+  - !!inc/file layers/poi-building-label.yml
   - !!inc/file layers/poi-railway.yml
   # - !!inc/file layers/road_shield_prefectural.yml
   # - !!inc/file layers/road_shield_national.yml


### PR DESCRIPTION
ビルのラベル名を追加しました。

最初は表示されているビルのみにラベルを追加したかったのですが、スタイルのみではできなかったので、

- rank: 25（主にポリゴンから生成されたpoi）
- wikidata を持っている（有名なビル）
- class を持たない（特定の用途の建物を含まない）

を指定してばらけさせてみました。

追加で、新宿西口駅からベルサール新宿グランドの道案内を想定して、デフォルトの場所を新宿周辺に設定してみました。
